### PR TITLE
Update example to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Prior to version 0.78.2, sshuttle used `netstat` to [list routes](https://github
 Simple alpine container with a minimal python is enough for `kuttle`. You can use the `kubectl` command below in order to spawn ready-to-use pod as a VPN server:
 
 ```sh
-kubectl run kuttle --image=alpine:latest --restart=Never -- sh -c 'apk add python --update && exec tail -f /dev/null'
+kubectl run kuttle --image=alpine:latest --restart=Never -- sh -c 'apk add python3 --update && exec tail -f /dev/null'
 sshuttle -r kuttle -e kuttle 0.0.0.0/0
 ```
 


### PR DESCRIPTION
The python apk package does no longer exist:
```
$ apk add python --update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
```

This PR updates the readme example to python3.