### PR TITLE
Adding a kubectl plugin

### DIFF
--- a/kubectl-kuttle
+++ b/kubectl-kuttle
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# start the sshuttle tunnel
+if [[ $1 == "start" ]]; then
+mkdir -p ~/.cache
+kubectl run kuttle --image=alpine:latest --restart=Never -- sh -c 'apk add python3 --update && exec tail -f /dev/null'
+sshuttle --remote kuttle --dns --daemon --pidfile ~/.cache/kuttle.pid --auto-hosts --ssh-cmd kuttle 0.0.0.0/0
+exit 0
+fi
+
+# stop the sshuttle tunnel
+if [[ $1 == "stop" ]]; then
+kill `cat ~/.cache/kuttle.pid`;
+kubectl delete pod/kuttle --force
+exit 0
+fi
+
+# help docs
+echo "kubectl kuttle [start/stop]"
+exit 1


### PR DESCRIPTION
This PR creates an additional bash script that acts as a plugin to `kubectl`. If this file, kuttle, and sshuttle are all in the user's path; then they may run `kubectl kuttle start` and `kubectl kuttle stop` to control their tunnel into the cluster.